### PR TITLE
[pg-boss] fixes internal middleware from swallowing jobs leading to failed jobs always completing

### DIFF
--- a/packages/pg-boss/src/internal-queue-middleware.service.ts
+++ b/packages/pg-boss/src/internal-queue-middleware.service.ts
@@ -21,13 +21,13 @@ export class InternalQueueMiddlewareService {
         const nextMiddleware = this.middlewares[i];
         ++i;
         if (nextMiddleware) {
-          nextMiddleware(job, cb);
+          return nextMiddleware(job, cb);
         } else {
-          next();
+          return next();
         }
       }
 
-      cb();
+      return cb();
     }
   }
 }

--- a/packages/pg-boss/src/queue.explorer.ts
+++ b/packages/pg-boss/src/queue.explorer.ts
@@ -27,7 +27,7 @@ export class QueueExplorer {
         const instance = providerMap.get(provider);
         const handler = async (job: PgBoss.Job<unknown>): Promise<void> => {
           this.logger.log(`Starting job ${job.id} => ${queueName}`)
-          middleware(job as any, async () => {
+          await middleware(job as any, async () => {
             await instance[key].call(instance, job);
           });
         };


### PR DESCRIPTION
**Issue**
- Failed jobs will always complete, even if calling `pgBoss.fail(job.id)` inside the job handler.

**Reason**
- This is because the internal middleware does not await the job handler promises. The handler will always complete. PGBoss handlers must throw errors in order to end up in a failed or retry state. Not awaiting the job may also crash the server if not handled correctly.

**Solution**
- Return the middleware result
- Await the internal middleware inside the work handler

fixes #2 